### PR TITLE
fix no such dir

### DIFF
--- a/src/helper.js
+++ b/src/helper.js
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import {promisify} from 'util';
+import {fileURLToPath} from 'url';
 
 import ncp from 'ncp';
 
@@ -10,8 +11,8 @@ const copy = promisify(ncp);
 
 const currentFileUrl = import.meta.url;
 const templateDir = path.resolve(
-    new URL(currentFileUrl).pathname,
-    '../../templates/clean-arch-node',
+	path.dirname(fileURLToPath(new URL(currentFileUrl))),
+	'../templates/clean-arch-node'
 );
 
 async function copyTemplateFiles(options) {


### PR DESCRIPTION
```
{
  err: [Error: ENOENT: no such file or directory, access 'G:\C:\Users\Jonas\AppData\Roaming\npm\node_modules\clean-setup\templates\clean-arch-node'] {
    errno: -4058,
    code: 'ENOENT',
    syscall: 'access',
    path: 'G:\\C:\\Users\\Jonas\\AppData\\Roaming\\npm\\node_modules\\clean-setup\\templates\\clean-arch-node'
  }
}
%s Invalid template name
```
fix for the above error